### PR TITLE
Fix double-render of auth pages

### DIFF
--- a/forgot_password.py
+++ b/forgot_password.py
@@ -130,5 +130,7 @@ def forgot_password_page():
 
     st.markdown('</div>', unsafe_allow_html=True)
 
-# Always call the page (app.py will import it conditionally)
-forgot_password_page()
+# Only show the page when executing this file directly. This prevents the
+# UI from rendering twice when the module is imported by ``app.py``.
+if __name__ == "__main__":
+    forgot_password_page()

--- a/login.py
+++ b/login.py
@@ -134,12 +134,16 @@ def login_page():
 
     st.markdown('</div>', unsafe_allow_html=True)
 
-# Boilerplate: if not logged_in, show login form; else show a message.
-if "logged_in" not in st.session_state:
-    st.session_state.logged_in = False
+# Boilerplate: when run directly, show the login form. This prevents the page
+# from rendering twice when imported from ``app.py``.
+if __name__ == "__main__":
+    if "logged_in" not in st.session_state:
+        st.session_state.logged_in = False
 
-if not st.session_state.logged_in:
-    login_page()
-else:
-    st.success("✅ You are already logged in. Automatically taking you to the dashboard...") 
-    # We will handle redirect in app.py below.
+    if not st.session_state.logged_in:
+        login_page()
+    else:
+        st.success(
+            "✅ You are already logged in. Automatically taking you to the dashboard..."
+        )
+        # We will handle redirect in app.py below.

--- a/signup.py
+++ b/signup.py
@@ -138,5 +138,7 @@ def signup_page():
 
     st.markdown('</div>', unsafe_allow_html=True)
 
-# Always call signup_page(), because app.py will import it conditionally
-signup_page()
+# When executed directly (``python signup.py``) show the sign-up form. Avoid
+# running on import so ``app.py`` can control when the UI is rendered.
+if __name__ == "__main__":
+    signup_page()


### PR DESCRIPTION
## Summary
- avoid executing login/signup/forgot password pages on module import
- add `if __name__ == "__main__"` guards so pages only render when run directly

## Testing
- `python3 -m py_compile *.py`
- `pip install -q -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_6840f8c460688325af8d03d572b8f217